### PR TITLE
Allow tests to timeout

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -2,3 +2,4 @@ Authors
 =======
 
 * Evan Kepner
+* David Li-Bland

--- a/mutatest/cli.py
+++ b/mutatest/cli.py
@@ -228,7 +228,8 @@ def cli_parser() -> argparse.ArgumentParser:
         "--nocov", action="store_true", help="Ignore coverage files for optimization."
     )
     parser.add_argument(
-        "--timeout_factor", help="If the tests take this much longer than expected, they are aborted.",
+        "--timeout_factor",
+        help="If the tests take this much longer than expected, they are aborted.",
         default=5,
         type=int,
     )
@@ -703,7 +704,7 @@ def main(args: argparse.Namespace) -> None:
         break_on_unknown=run_mode.break_on_unknown,
         break_on_timeout=run_mode.break_on_timeout,
         ignore_coverage=args.nocov,
-        max_runtime=args.timeout_factor*clean_runtime_1.seconds
+        max_runtime=args.timeout_factor * clean_runtime_1.seconds,
     )
 
     results_summary = run.run_mutation_trials(

--- a/mutatest/cli.py
+++ b/mutatest/cli.py
@@ -56,6 +56,11 @@ class RunMode(NamedTuple):
         # Set to TRUE for the cli as a default, may add CLI control options later
         return True
 
+    @property
+    def break_on_timeout(self) -> bool:
+        # Set to TRUE for the cli as a default, may add CLI control options later
+        return True
+
 
 class TrialTimes(NamedTuple):
     """Container for trial run times used in summary report."""
@@ -221,6 +226,11 @@ def cli_parser() -> argparse.ArgumentParser:
     parser.add_argument("--debug", action="store_true", help="Turn on DEBUG level logging output.")
     parser.add_argument(
         "--nocov", action="store_true", help="Ignore coverage files for optimization."
+    )
+    parser.add_argument(
+        "--timeout_factor", help="If the tests take this much longer than expected, they are aborted.",
+        default=5,
+        type=int,
     )
 
     return parser
@@ -691,7 +701,9 @@ def main(args: argparse.Namespace) -> None:
         break_on_survival=run_mode.break_on_survival,
         break_on_error=run_mode.break_on_error,
         break_on_unknown=run_mode.break_on_unknown,
+        break_on_timeout=run_mode.break_on_timeout,
         ignore_coverage=args.nocov,
+        max_runtime=args.timeout_factor*clean_runtime_1.seconds
     )
 
     results_summary = run.run_mutation_trials(
@@ -721,6 +733,7 @@ def main(args: argparse.Namespace) -> None:
     LOGGER.info("CLI Report:\n\n%s", cli_report)
     LOGGER.info("Trial Summary Report:\n\n%s\n", display_results.summary)
     LOGGER.info("Detected mutations:%s\n", display_results.detected)
+    LOGGER.info("Timedout mutations:%s\n", display_results.timedout)
     LOGGER.info("Surviving mutations:%s\n", display_results.survived)
 
     if args.output:

--- a/mutatest/report.py
+++ b/mutatest/report.py
@@ -32,6 +32,7 @@ class DisplayResults(NamedTuple):
 
     summary: str
     survived: str
+    timedout: str
     detected: str
 
 
@@ -78,6 +79,7 @@ def analyze_mutant_trials(trial_results: List[MutantTrialResult]) -> Tuple[str, 
         Overall mutation trial summary:
         ===============================
         DETECTED: x
+        TIMEOUT: w
         SURVIVED: y
         ...
 
@@ -98,6 +100,7 @@ def analyze_mutant_trials(trial_results: List[MutantTrialResult]) -> Tuple[str, 
     status = get_status_summary(trial_results)
 
     detected = get_reported_results(trial_results, "DETECTED")
+    timeouts = get_reported_results(trial_results, "TIMEOUT")
     survived = get_reported_results(trial_results, "SURVIVED")
     errors = get_reported_results(trial_results, "ERROR")
     unknowns = get_reported_results(trial_results, "UNKNOWN")
@@ -112,12 +115,12 @@ def analyze_mutant_trials(trial_results: List[MutantTrialResult]) -> Tuple[str, 
 
     # prepare display of summary results, no color applied
     display_summary = "\n".join(report_sections)
-    display_survived, display_detected = "", ""
+    display_survived, display_timedout, display_detected = "", "", ""
 
     # build the breakout sections for each type
     section_header = "Mutations by result status"
     report_sections.append("\n".join(["\n", section_header, "=" * len(section_header)]))
-    for rpt_results in [survived, detected, errors, unknowns]:
+    for rpt_results in [survived, timeouts, detected, errors, unknowns]:
         if rpt_results.mutants:
             section = build_report_section(rpt_results.status, rpt_results.mutants)
             report_sections.append(section)
@@ -125,13 +128,16 @@ def analyze_mutant_trials(trial_results: List[MutantTrialResult]) -> Tuple[str, 
             if rpt_results.status == "SURVIVED":
                 display_survived = run.colorize_output(section, "red")
 
+            if rpt_results.status == "TIMEOUT":
+                display_timedout = run.colorize_output(section, "yellow")
+
             if rpt_results.status == "DETECTED":
                 display_detected = run.colorize_output(section, "green")
 
     return (
         "\n".join(report_sections),
         DisplayResults(
-            summary=display_summary, detected=display_detected, survived=display_survived
+            summary=display_summary, detected=display_detected, timedout=display_timedout, survived=display_survived
         ),
     )
 

--- a/mutatest/report.py
+++ b/mutatest/report.py
@@ -137,7 +137,10 @@ def analyze_mutant_trials(trial_results: List[MutantTrialResult]) -> Tuple[str, 
     return (
         "\n".join(report_sections),
         DisplayResults(
-            summary=display_summary, detected=display_detected, timedout=display_timedout, survived=display_survived
+            summary=display_summary,
+            detected=display_detected,
+            timedout=display_timedout,
+            survived=display_survived,
         ),
     )
 

--- a/mutatest/run.py
+++ b/mutatest/run.py
@@ -387,8 +387,7 @@ def trial_output_check_break(
 
 
 def create_mutation_run_trial(
-    genome: Genome, target_idx: LocIndex, mutation_op: Any, test_cmds: List[str],
-    max_runtime: float
+    genome: Genome, target_idx: LocIndex, mutation_op: Any, test_cmds: List[str], max_runtime: float
 ) -> MutantTrialResult:
     """Run a single mutation trial by creating a new mutated cache file, running the
     test commands, and then removing the mutated cache file.
@@ -407,8 +406,9 @@ def create_mutation_run_trial(
     mutant = genome.mutate(target_idx, mutation_op, write_cache=True)
     try:
         mutant_trial = subprocess.run(
-            test_cmds, capture_output=capture_output(LOGGER.getEffectiveLevel()),
-            timeout=max_runtime
+            test_cmds,
+            capture_output=capture_output(LOGGER.getEffectiveLevel()),
+            timeout=max_runtime,
         )
     except subprocess.TimeoutExpired:
         cache.remove_existing_cache_files(mutant.src_file)
@@ -476,7 +476,7 @@ def run_mutation_trials(src_loc: Path, test_cmds: List[str], config: Config) -> 
                 target_idx=sample_idx,
                 mutation_op=current_mutation,
                 test_cmds=test_cmds,
-                max_runtime=config.max_runtime
+                max_runtime=config.max_runtime,
             )
 
             results.append(trial_results)

--- a/mutatest/transformers.py
+++ b/mutatest/transformers.py
@@ -376,9 +376,7 @@ class MutateAST(ast.NodeTransformer):
         # More likely to generate useful mutants in the positive case.
         if slice.lower is not None and slice.upper is not None:
             if isinstance(slice.upper, ast.Num):
-                idx = LocIndex(
-                    "SliceRC", node.lineno, node.col_offset, "Slice_UPosToZero"
-                )
+                idx = LocIndex("SliceRC", node.lineno, node.col_offset, "Slice_UPosToZero")
                 slice_mutations["Slice_UPosToZero"] = ast.Slice(
                     lower=slice.lower, upper=ast.Num(n=slice.upper.n - 1), step=slice.step
                 )
@@ -388,9 +386,7 @@ class MutateAST(ast.NodeTransformer):
                 self.locs.add(idx)
 
             if isinstance(slice.upper, ast.UnaryOp):
-                idx = LocIndex(
-                    "SliceRC", node.lineno, node.col_offset, "Slice_UNegToZero"
-                )
+                idx = LocIndex("SliceRC", node.lineno, node.col_offset, "Slice_UNegToZero")
 
                 slice_mutations["Slice_UNegToZero"] = ast.Slice(
                     lower=slice.lower,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -364,6 +364,45 @@ def single_binop_file_with_bad_test(tmp_path_factory):
     bad_test_fn.unlink()
 
 
+@pytest.fixture(scope="session")
+def while_loop_with_timeout(tmp_path_factory):
+    """A while loop where mutants will timeout."""
+    contents = dedent(
+        """\
+    def odd_loop(x):
+        a = True
+        while True:
+            if a:
+                break
+        return x
+
+    print(odd_loop(5))
+    """
+    )
+
+    test_timeout = dedent(
+        """\
+    from timeout import odd_loop
+
+    def test_odd_loop():
+        assert True
+    """
+    )
+
+    folder = tmp_path_factory.mktemp("timeout_while")
+    fn = folder / "timeout.py"
+    bad_test_fn = folder / "test_timeout.py"
+
+    for f, c in [(fn, contents), (bad_test_fn, test_timeout)]:
+        with open(f, "w") as output_fn:
+            output_fn.write(c)
+
+    yield FileAndTest(fn, bad_test_fn)
+
+    fn.unlink()
+    bad_test_fn.unlink()
+
+
 ####################################################################################################
 # TRANSFORMERS: COMPARE FIXTURES
 ####################################################################################################
@@ -445,7 +484,7 @@ def if_file(tmp_path_factory):
 
 @pytest.fixture(scope="session")
 def if_expected_locs():
-    """Exepected locations in the if_statement."""
+    """Expected locations in the if_statement."""
     return [
         LocIndex(ast_class="If", lineno=2, col_offset=4, op_type="If_Statement"),
         LocIndex(ast_class="If", lineno=4, col_offset=9, op_type="If_Statement"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,8 @@ def mock_trial_results(mock_Mutant):
         MutantTrialResult(mock_Mutant, return_code=0),  # SURVIVED
         MutantTrialResult(mock_Mutant, return_code=1),  # DETECTED
         MutantTrialResult(mock_Mutant, return_code=2),  # ERROR
-        MutantTrialResult(mock_Mutant, return_code=3),  # UNKNOWN
+        MutantTrialResult(mock_Mutant, return_code=3),  # TIMEOUT
+        MutantTrialResult(mock_Mutant, return_code=4),  # UNKNOWN
     ]
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,7 +54,7 @@ def mock_args(tmp_path, binop_file):
         exception=None,
         debug=False,
         nocov=True,
-        timeout_factor=2
+        timeout_factor=2,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,6 +35,7 @@ class MockArgs(NamedTuple):
     exception: Optional[int]
     debug: Optional[bool]
     nocov: Optional[bool]
+    timeout_factor: Optional[int]
 
 
 @pytest.fixture
@@ -53,6 +54,7 @@ def mock_args(tmp_path, binop_file):
         exception=None,
         debug=False,
         nocov=True,
+        timeout_factor=2
     )
 
 
@@ -224,8 +226,9 @@ def test_main(monkeypatch, mock_args, mock_results_summary):
          - SURVIVED: 1
          - DETECTED: 1
          - ERROR: 1
+         - TIMEOUT: 1
          - UNKNOWN: 1
-         - TOTAL RUNS: 4
+         - TOTAL RUNS: 5
          - RUN DATETIME: 2019-01-01 00:00:00
 
 
@@ -235,6 +238,11 @@ def test_main(monkeypatch, mock_args, mock_results_summary):
 
         SURVIVED
         --------
+         - src.py: (l: 1, c: 2) - mutation from <class '_ast.Add'> to <class '_ast.Mult'>
+
+
+        TIMEOUT
+        -------
          - src.py: (l: 1, c: 2) - mutation from <class '_ast.Add'> to <class '_ast.Mult'>
 
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -16,7 +16,7 @@ from mutatest.report import (
 )
 
 
-@pytest.mark.parametrize("status", ["SURVIVED", "DETECTED", "ERROR", "UNKNOWN"])
+@pytest.mark.parametrize("status", ["SURVIVED", "DETECTED", "ERROR", "TIMEOUT", "UNKNOWN"])
 def test_get_reported_results(status, mock_trial_results):
     """Ensure status reporting per type returns appropriate lists."""
     reported = get_reported_results(mock_trial_results, status)
@@ -33,7 +33,8 @@ def test_get_status_summary(mock_trial_results):
         "DETECTED": 1,
         "ERROR": 1,
         "UNKNOWN": 1,
-        "TOTAL RUNS": 4,
+        "TIMEOUT": 1,
+        "TOTAL RUNS": 5,
         "RUN DATETIME": str(datetime(2019, 1, 1)),
     }
 
@@ -82,7 +83,7 @@ def test_analyze_mutant_trials(mock_trial_results):
     SURVIVED
     --------
      - src.py: (l: 1, c: 2) - mutation from <class '_ast.Add'> to <class '_ast.Mult'>
-
+     
 
     DETECTED
     --------

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -83,7 +83,7 @@ def test_analyze_mutant_trials(mock_trial_results):
     SURVIVED
     --------
      - src.py: (l: 1, c: 2) - mutation from <class '_ast.Add'> to <class '_ast.Mult'>
-     
+
 
     DETECTED
     --------

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -19,7 +19,7 @@ from mutatest.run import BaselineTestException, Config, MutantTrialResult
 from mutatest.transformers import LocIndex
 
 
-RETURN_CODE_MAPPINGS = [(0, "SURVIVED"), (1, "DETECTED"), (2, "ERROR"), (3, "UNKNOWN")]
+RETURN_CODE_MAPPINGS = [(0, "SURVIVED"), (1, "DETECTED"), (2, "ERROR"), (3, "TIMEOUT"), (4, "UNKNOWN")]
 
 
 @pytest.fixture
@@ -73,7 +73,8 @@ def test_create_mutation_and_run_trial(returncode, expected_status, monkeypatch,
     monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
 
     trial = run.create_mutation_run_trial(
-        genome=genome, target_idx=target_idx, mutation_op=mutation_op, test_cmds=["pytest"]
+        genome=genome, target_idx=target_idx, mutation_op=mutation_op, test_cmds=["pytest"],
+        max_runtime=10
     )
 
     # mutated cache files should be removed after trial run
@@ -187,9 +188,10 @@ def test_get_genome_group_folder_and_file(tmp_path):
         (0, Config(break_on_survival=True)),
         (1, Config(break_on_detected=True)),
         (2, Config(break_on_error=True)),
-        (3, Config(break_on_unknown=True)),
+        (3, Config(break_on_timeout=True)),
+        (4, Config(break_on_unknown=True)),
     ],
-    ids=["survival", "detected", "error", "unknown"],
+    ids=["survival", "detected", "error", "timeout", "unknown"],
 )
 def test_break_on_check(return_code, config, mock_Mutant, mock_LocIdx):
     # positive case

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -19,7 +19,13 @@ from mutatest.run import BaselineTestException, Config, MutantTrialResult
 from mutatest.transformers import LocIndex
 
 
-RETURN_CODE_MAPPINGS = [(0, "SURVIVED"), (1, "DETECTED"), (2, "ERROR"), (3, "TIMEOUT"), (4, "UNKNOWN")]
+RETURN_CODE_MAPPINGS = [
+    (0, "SURVIVED"),
+    (1, "DETECTED"),
+    (2, "ERROR"),
+    (3, "TIMEOUT"),
+    (4, "UNKNOWN"),
+]
 
 
 @pytest.fixture
@@ -73,8 +79,11 @@ def test_create_mutation_and_run_trial(returncode, expected_status, monkeypatch,
     monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
 
     trial = run.create_mutation_run_trial(
-        genome=genome, target_idx=target_idx, mutation_op=mutation_op, test_cmds=["pytest"],
-        max_runtime=10
+        genome=genome,
+        target_idx=target_idx,
+        mutation_op=mutation_op,
+        test_cmds=["pytest"],
+        max_runtime=10,
     )
 
     # mutated cache files should be removed after trial run


### PR DESCRIPTION
This PR is a tentative move towards allowing tests to timeout, addressing #16. At a high level it
- Records the time taken for the tests with the original code
- If the tests on a mutation take longer than a (configurable) factor of the tests on the original code, the test are aborted and the mutation is logged as "timedout" (since we were unable to determine whether it would have survived or would have been detected).

Pull requests will be reviewed when the automated CICD checks successfully pass.
