### PR TITLE
Added exclusion for assert statements

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,3 +13,4 @@ Contributors
 
 * David Li-Bland
 * Alireza Aghamohammadi
+* Martin Ruefenacht

--- a/mutatest/api.py
+++ b/mutatest/api.py
@@ -221,6 +221,13 @@ class Genome:
 
             with open(self.source_file, "rb") as src_stream:
                 self._ast = ast.parse(src_stream.read())
+
+                # add parent linkage to all nodes
+                self._ast.parent = None
+                for parent in ast.walk(self._ast):
+                    for child in ast.iter_child_nodes(parent):
+                        child.parent = parent
+
         return self._ast
 
     @property

--- a/mutatest/tests/conftest.py
+++ b/mutatest/tests/conftest.py
@@ -874,3 +874,53 @@ def slice_expected_locs():
         LocIndex(ast_class="Slice_Swap", lineno=4, col_offset=14, op_type="Slice_UnboundUpper"),
         LocIndex(ast_class="Slice_Swap", lineno=6, col_offset=14, op_type="Slice_UnboundUpper"),
     ]
+
+
+####################################################################################################
+# TRANSFORMERS: ASSERT FIXTURES
+####################################################################################################
+
+
+@pytest.fixture(scope="session")
+def assert_file(tmp_path_factory):
+    """A simple python file with the slice attributes."""
+    contents = dedent(
+        """\
+    def my_func(a, b, c):
+        assert a == b
+        assert (a == b) == c
+        d = a == b
+
+        return a, b, c
+    """
+    )
+
+    fn = tmp_path_factory.mktemp("assert") / "assert.py"
+
+    with open(fn, "w") as output_fn:
+        output_fn.write(contents)
+
+    yield fn
+
+    fn.unlink()
+
+
+@pytest.fixture(scope="session")
+def assert_expected_locs():
+    """The assert expected locations based on the fixture."""
+    # Py 3.7
+    if sys.version_info < (3, 8):
+        return {
+            LocIndex(ast_class="Compare", lineno=4, col_offset=8, op_type=ast.Eq),
+        }
+    # Py 3.8
+    return {
+        LocIndex(
+            ast_class="Compare",
+            lineno=4,
+            col_offset=8,
+            op_type=ast.Eq,
+            end_lineno=4,
+            end_col_offset=14,
+        )
+    }

--- a/mutatest/tests/test_api.py
+++ b/mutatest/tests/test_api.py
@@ -22,6 +22,28 @@ def test_genome_ast(binop_file, binop_expected_locs):
     assert genome.targets == binop_expected_locs
 
 
+def test_genome_ast_parentage(assert_file):
+    """Test that the AST builds correctly with parents."""
+    genome = Genome(source_file=assert_file)
+
+    for node in ast.walk(genome.ast):
+        if isinstance(node, ast.Module):
+            assert node.parent is None
+
+        else:
+            assert node.parent is not None
+
+
+def test_genome_assert_exclusion(assert_file, assert_expected_locs):
+    """Test that the LocIndexes are only output for non-assert statements."""
+    genome = Genome(source_file=assert_file)
+
+    print(genome.targets)
+
+    assert len(genome.targets) == 1
+    assert genome.targets == assert_expected_locs
+
+
 def test_create_mutant_with_cache(binop_file, stdoutIO):
     """Change ast.Add to ast.Mult in a mutation including pycache changes."""
     genome = Genome(source_file=binop_file)


### PR DESCRIPTION
<!--
Thanks for your pull-request! For efficient review please:

1. Review the [contribution guidelines](https://mutatest.readthedocs.io/en/latest/contributing.html).
2. Optionally, append your name to [Authors.rst](https://github.com/EvanKepner/mutatest/blob/master/AUTHORS.rst).
3. Include a description of the change including examples to reproduce if necessary.

Pull requests will be reviewed when the automated CI checks successfully pass.
-->

When mutations are found during the inspection phase with the MutateAST we do not add them if they have an Assert node in the parentage (directly or indirectly). This excludes mutations in cases such as:

```
assert (a == b)
assert (a == b) == c
```

Mutations in non-assert code are not excluded.

This PR resolves #26. 

- [x] Add parent links to the Genome class.
- [x] Add test for parentage generation. 
- [x] Add checks to MutateAST to check whether an Assert is in the parentage of the given visited Node. If an Assert is present, then the LocIndex is not added to the possible mutation targets.
- [x] Add an assert_file and corresponding expected_assert_locs fixture to conftest.
- [x] Add test for testing the assert exclusion.

- [ ] Typing check of tox has an issue, because ast.AST does not have a parent attribute. We add it dynamically. We can either ignore this or subclass ast.AST and add a parent attribute. We only need to change the typing information in transformers.py for that to work.

PR Checklist:

- [x] Description of the change is included.
- [ ] Ensure all automated CI checks pass (though ask for help if needed).
