### PR TITLE
Disable sampling for nlocations=0

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,3 +13,4 @@ Contributors
 
 * David Li-Bland
 * Alireza Aghamohammadi
+* Stephan Lukasczyk

--- a/mutatest/cli.py
+++ b/mutatest/cli.py
@@ -198,7 +198,7 @@ def cli_parser() -> argparse.ArgumentParser:
         metavar="INT",
         help=(
             "Number of locations in code to randomly select for mutation from possible targets. "
-            "(default: 10)"
+            "(default: 10; a value of 0 will consider all targets without selection)"
         ),
     )
     parser.add_argument(

--- a/mutatest/run.py
+++ b/mutatest/run.py
@@ -230,10 +230,10 @@ def get_mutation_sample_locations(
     mutation_sample = sample_space
 
     # natural Falsey evaluation of n_locations=0 requires exact None check
-    if n_locations <= 0:
+    if n_locations < 0:
         raise ValueError("n_locations must be greater or equal to zero.")
 
-    if n_locations <= len(sample_space):
+    if 0 < n_locations <= len(sample_space):
         LOGGER.info(
             "%s",
             colorize_output(

--- a/mutatest/tests/test_run.py
+++ b/mutatest/tests/test_run.py
@@ -147,7 +147,7 @@ def test_generate_sample_FileNotFoundError(binop_file, sorted_binop_expected_loc
     assert list(gt.loc_idx for gt in sample) == sorted_binop_expected_locs
 
 
-@pytest.mark.parametrize("popsize, nlocs, nexp", [(3, 1, 1), (3, 2, 2), (3, 5, 3)])
+@pytest.mark.parametrize("popsize, nlocs, nexp", [(3, 1, 1), (3, 2, 2), (3, 5, 3), (3, 0, 3)])
 def test_get_mutation_sample_locations(popsize, nlocs, nexp, mock_LocIdx):
     """Test sample size draws for the mutation sample."""
     mock_src_file = Path("source.py")
@@ -157,13 +157,12 @@ def test_get_mutation_sample_locations(popsize, nlocs, nexp, mock_LocIdx):
     assert len(result) == nexp
 
 
-@pytest.mark.parametrize("nloc", [0, -1], ids=["zero", "negative integer"])
-def test_get_mutation_sample_locations_ValueError(nloc, mock_LocIdx):
-    """Zero and negative integer sample sizes raise a value error."""
+def test_get_mutation_sample_locations_ValueError(mock_LocIdx):
+    """Negative integer sample sizes raise a value error."""
     ggt = [GenomeGroupTarget(Path("src.py"), mock_LocIdx)]
 
     with pytest.raises(ValueError):
-        _ = run.get_mutation_sample_locations(ggt, nloc)
+        _ = run.get_mutation_sample_locations(ggt, -1)
 
 
 def test_get_genome_group_folder_and_file(tmp_path):


### PR DESCRIPTION
In case the user does not know how many mutation locations are existing
and they want to run mutation for all of them, using a value of `0` for
the `nlocations` parameter seems like a natural choice, especially since
many tools treat a value of `0` for a limit as infinity/all possible.

Also, the exception message in the `get_mutation_sample_locations`
function suggests that `0` might be a reasonable value.  Obviously,
taking an empty sample with this value does not make too much sense, as
this would disable mutation at all.

<!--
Thanks for your pull-request! For efficient review please:

1. Review the [contribution guidelines](https://mutatest.readthedocs.io/en/latest/contributing.html).
2. Optionally, append your name to [Authors.rst](https://github.com/EvanKepner/mutatest/blob/master/AUTHORS.rst).
3. Include a description of the change including examples to reproduce if necessary.

Pull requests will be reviewed when the automated CI checks successfully pass.
-->

PR Checklist:

- [x] Description of the change is included.
- [ ] Ensure all automated CI checks pass (though ask for help if needed).
   It seems that `black` formats code differently in CI than it does on my machine. It also causes changes on files this PR does not even touch, which I cannot really explain right now.
